### PR TITLE
Change relaunch shortcut to avoid conflict on 10.15

### DIFF
--- a/Commands/Restart TextMate.plist
+++ b/Commands/Restart TextMate.plist
@@ -23,7 +23,7 @@
 	<key>input</key>
 	<string>none</string>
 	<key>keyEquivalent</key>
-	<string>^@q</string>
+	<string>^~@q</string>
 	<key>name</key>
 	<string>Relaunch TextMate</string>
 	<key>output</key>


### PR DESCRIPTION
On 10.15 Catalina and later, the shortcut previously used (⌃⌘Q) now locks the computer (Apple menu > Lock Screen). It is intercepted by the window server, so the Relaunch Textmate shortcut stopped working when this was introduced.