### PR TITLE
Copy as RTF: Fix error when theme uses 3-digit colors (#XXX)

### DIFF
--- a/Support/lib/copy_as_rtf.rb
+++ b/Support/lib/copy_as_rtf.rb
@@ -48,10 +48,15 @@ class RtfExporter
   end
   
   def hex_color_to_rtf hex
-    hex =~ /#(..)(..)(..)/
-    r = $1.hex
-    g = $2.hex
-    b = $3.hex
+    if hex =~ /#(.{1,2})(.{1,2})(.{1,2})/
+      r = $1.hex
+      g = $2.hex
+      b = $3.hex
+    else
+      r = 0
+      g = 0
+      b = 0
+    end
     return "\\red#{r}\\green#{g}\\blue#{b};"
   end
   


### PR DESCRIPTION
In my theme I used a color "#777" which is rendered fine in TextMate but lead to an error in "Copy as RTF" command.

/Users/sema/Library/Application Support/TextMate/Managed/Bundles/TextMate.tmbundle/Support/lib/copy_as_rtf.rb:52:in \`hex_color_to_rtf': undefined method `hex' for nil:NilClass (NoMethodError)

In this fix I have also added a fallback to `#000` (black) color in case there are other ways to specify colors - at least there won't be an error.
